### PR TITLE
Optimize consecutive jumps better

### DIFF
--- a/robots-bytecode.py
+++ b/robots-bytecode.py
@@ -419,8 +419,8 @@ class Compiler:
                         self.jump_labels.append(Label(location=location, direction=dir_vec[token.value]))
                     case TokenType.T_COND:
                         # Both paths for conditional
-                        # Set refcounts so they don't get optimized out.
-                        self.jump_labels.append(Label(location=location, direction=dir_vec["<"], refcount=1))
+                        # Set refcount for JZ so it doesn't get optimized out.
+                        self.jump_labels.append(Label(location=location, direction=dir_vec["<"], refcount=0))
                         self.jump_labels.append(Label(location=location, direction=dir_vec[">"], refcount=1))
                 if len(self.jump_labels) >= 255:
                     raise ValueError(f"Too many labels!")
@@ -601,8 +601,9 @@ class Compiler:
         start_offset = len(header)
         offset = start_offset
 
-        for path_index in self.entry_points:
-            self.maximally_extend_path(path_index)
+        for label in self.jump_labels:
+            # This does a little extra pointless work.
+            self.maximally_extend_path(self.get_label_index(label))
 
         path_stack.extend(self.entry_points)
 


### PR DESCRIPTION
Before this change, there were too many consecutive jumps. Bytecode for room 3 before change:

  000c	[80] PUSH @00
  000d	[81] PUSH @01
  000f	[4f] JUMP 10
  0010	[3a] DUP
  0011	[82] PUSH @02
  0012	[30] SUB
  0013	[3a] DUP
  0015	[4f] JUMP 16
  0017	[5f] JZ 1e
  0019	[4f] JUMP 1a    ;; Notice many consecutive jumps
  001b	[4f] JUMP 1c
  001d	[4f] JUMP 10
  001e	[38] POP
  0020	[4f] JUMP 21    ;; And no-op jumps
  0021	[39] SWAP
  0022	[3a] DUP
  0024	[4f] JUMP 25
  0026	[5f] JZ 2e
  0028	[4f] JUMP 29
  0029	[32] MUL
  002b	[4f] JUMP 2c
  002d	[4f] JUMP 21
  002e	[38] POP
  002f	[00] HALT

Execution time: 0.0709ms

Bytecode for room 3 after change:

  000c	[80] PUSH @00
  000d	[81] PUSH @01
  000f	[4f] JUMP 10
  0010	[3a] DUP
  0011	[82] PUSH @02
  0012	[30] SUB
  0013	[3a] DUP
  0015	[5f] JZ 18
  0017	[4f] JUMP 10
  0018	[38] POP
  001a	[4f] JUMP 1b
  001b	[39] SWAP
  001c	[3a] DUP
  001e	[5f] JZ 22
  001f	[32] MUL
  0021	[4f] JUMP 1b
  0022	[38] POP
  0023	[00] HALT

Execution time: 0.0548ms
23% increase in speed with 6 JMP instructions optimized out.